### PR TITLE
:hammer: Schedule R CMD check

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,6 +5,9 @@ on:
     branches: [main, master, development, documentation]
   pull_request:
     branches: [main, master, development, documentation]
+  workflow_dispatch:
+    schedule:
+      - cron: '0 10 * * 1'
 
 name: R-CMD-check
 


### PR DESCRIPTION
* APIs can be volatile: breaking changes, discontinued endpoints etc. The R CMD check is scheduled to run every mondays to continously mmonitor the state of the APIs.

NOTE: This only checks API providers defined in test-CICD!